### PR TITLE
Dependency Changes & Trivial Timeout Prevention

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,23 +44,23 @@
     "version": "oclif-dev readme && git add README.md"
   },
   "dependencies": {
-    "@oclif/command": "^1",
-    "@oclif/config": "^1",
+    "@oclif/command": "^1.8.18",
+    "@oclif/config": "^1.18.5",
     "@oclif/errors": "^1",
     "@salesforce/command": "^4.2.2",
     "@salesforce/core": "^2.37.1",
     "@types/node": "^17.0.21",
-    "@types/puppeteer": "^5.4.6",
+    "@types/puppeteer": "^5.4.7",
     "install": "^0.13.0",
     "npm": "^8.18.0",
-    "puppeteer": "^18.0.5",
-    "sfdx-cli": "^7.165.0",
+    "puppeteer": "^18.2.1",
+    "sfdx-cli": "^7.172.0",
     "tslib": "^2"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",
-    "@oclif/plugin-help": "^5.1.12",
-    "@oclif/test": "^2.1.1",
+    "@oclif/plugin-help": "^5.1.15",
+    "@oclif/test": "^2.2.3",
     "@salesforce/dev-config": "^3.0.1",
     "@salesforce/dev-scripts": "^2.0.1",
     "@salesforce/prettier-config": "^0",
@@ -68,10 +68,10 @@
     "@types/chai": "^4.3.3",
     "@types/jsforce": "^1.9.29",
     "@types/mocha": "^9.1.0",
-    "@typescript-eslint/eslint-plugin": "^5.36.1",
-    "@typescript-eslint/parser": "^5.36.1",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
+    "@typescript-eslint/parser": "^5.40.0",
     "chai": "^4",
-    "eslint": "^8.23.0",
+    "eslint": "^8.25.0",
     "eslint-config-oclif": "^4.0.0",
     "eslint-config-prettier": "^8",
     "eslint-config-salesforce": "^0",
@@ -88,6 +88,6 @@
     "pretty-quick": "^3",
     "sinon": "13.0.1",
     "ts-node": "^10",
-    "typescript": "4.5.5"
+    "typescript": "4.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfdx-deliverability-access",
   "description": "SFDX Plugin to set Email Deliverability Access Level for an org via command line. This project uses Puppeteer and headless browsing to open Setup in the target org and set Email Deliverability Access Level to the desired value.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "gfarb @gfarb",
   "bugs": "https://github.com/gfarb/sfdx-deliverability-access/issues",
   "engines": {

--- a/src/commands/deliverability/access.ts
+++ b/src/commands/deliverability/access.ts
@@ -90,7 +90,7 @@ export default class Access extends SfdxCommand {
   private async toggleDeliverability(accessUrl: string, accessLevelValue: string): Promise<void> {
     let browser;
     let error;
-    this.ux.setSpinnerStatus('Opening browser.');
+    this.ux.setSpinnerStatus('Launching headless browser');
     try {
       browser = await puppeteer.launch({
         headless: true,
@@ -98,7 +98,7 @@ export default class Access extends SfdxCommand {
       });
       const page = await browser.newPage();
       await page.goto(accessUrl);
-      this.ux.setSpinnerStatus('Waiting for page to load.');
+      this.ux.setSpinnerStatus('Waiting for page to load');
       const frame = await page.waitForSelector(
         '#setupComponent > div.setupcontent > div > div > force-aloha-page > div > iframe'
       );
@@ -106,7 +106,7 @@ export default class Access extends SfdxCommand {
       const accessLevelField = await contentFrame?.waitForSelector(
         '#thePage\\:theForm\\:editBlock\\:sendEmailAccessControlSection\\:sendEmailAccessControl\\:sendEmailAccessControlSelect'
       );
-      this.ux.setSpinnerStatus('Selecting Deliverability Access Level.');
+      this.ux.setSpinnerStatus('Selecting Deliverability Access Level');
       await accessLevelField?.select(accessLevelValue);
       await contentFrame?.click('#thePage\\:theForm\\:editBlock\\:buttons\\:saveBtn');
       await contentFrame?.waitForSelector('#thePage\\:theForm\\:successText');

--- a/src/commands/deliverability/access.ts
+++ b/src/commands/deliverability/access.ts
@@ -55,7 +55,8 @@ export default class Access extends SfdxCommand {
     const accessLevel = this.flags.level as string;
     const accessLevelValue = String(accessValuesMap.get(accessLevel?.toLowerCase()));
     if (accessLevelValue !== 'undefined' && Number(accessLevelValue) > -1 && Number(accessLevelValue) < 3) {
-      const accessUrl: string = await this.parseOrgData(String(this.flags.user));
+      const accessUrl = await this.parseOrgData(String(this.flags.user));
+      if (accessUrl === undefined) return;
       try {
         void this.toggleDeliverability(accessUrl, accessLevelValue);
       } catch (error) {
@@ -66,7 +67,7 @@ export default class Access extends SfdxCommand {
     }
   }
 
-  private async parseOrgData(user: string): Promise<string> {
+  private async parseOrgData(user: string): Promise<string | void> {
     try {
       const orgDataCommand =
         user !== 'undefined' && user?.length > 0
@@ -82,7 +83,7 @@ export default class Access extends SfdxCommand {
       this.stopSpinnerAndLogError(
         "Unable to parse url from 'sfdx force:org:open' command. Please make sure you have a default org set or you are passing a valid username/alias with the '-u' or '--user' flag."
       );
-      return 'undefined';
+      return;
     }
   }
 

--- a/src/commands/deliverability/access.ts
+++ b/src/commands/deliverability/access.ts
@@ -90,6 +90,7 @@ export default class Access extends SfdxCommand {
   private async toggleDeliverability(accessUrl: string, accessLevelValue: string): Promise<void> {
     let browser;
     let error;
+    this.ux.setSpinnerStatus('Opening browser.');
     try {
       browser = await puppeteer.launch({
         headless: true,
@@ -97,6 +98,7 @@ export default class Access extends SfdxCommand {
       });
       const page = await browser.newPage();
       await page.goto(accessUrl);
+      this.ux.setSpinnerStatus('Waiting for page to load.');
       const frame = await page.waitForSelector(
         '#setupComponent > div.setupcontent > div > div > force-aloha-page > div > iframe'
       );
@@ -104,6 +106,7 @@ export default class Access extends SfdxCommand {
       const accessLevelField = await contentFrame?.waitForSelector(
         '#thePage\\:theForm\\:editBlock\\:sendEmailAccessControlSection\\:sendEmailAccessControl\\:sendEmailAccessControlSelect'
       );
+      this.ux.setSpinnerStatus('Selecting Deliverability Access Level.');
       await accessLevelField?.select(accessLevelValue);
       await contentFrame?.click('#thePage\\:theForm\\:editBlock\\:buttons\\:saveBtn');
       await contentFrame?.waitForSelector('#thePage\\:theForm\\:successText');


### PR DESCRIPTION
Updates to dependencies & attempt to prevent trivial timeout errors from `oclif` which seems to occur when spinner status is not updated in 10 seconds.

```
(node:8234) UnhandledPromiseRejectionWarning: Error: timed out
    at Object.error (/usr/local/lib/node_modules/sfdx-cli/node_modules/@oclif/core/lib/errors/index.js:28:15)
    at /usr/local/lib/node_modules/sfdx-cli/node_modules/@oclif/core/lib/cli-ux/index.js:25:66
    at async flush (/usr/local/lib/node_modules/sfdx-cli/node_modules/@oclif/core/lib/cli-ux/index.js:124:9)
```